### PR TITLE
Update model version retrieval in deployment workflow

### DIFF
--- a/.github/workflows/06-train-and-deploy.yml
+++ b/.github/workflows/06-train-and-deploy.yml
@@ -176,12 +176,12 @@ jobs:
           --workspace-name todozi-ml-ws
         
         # Get the version that was just registered
-        model_version=$(az ml model show \
+        model_version=$(az ml model list \
           --name diabetes-model \
           --resource-group todozi-data-science-rg \
           --workspace-name todozi-ml-ws \
-          --query version \
-          -o tsv | head -n 1)
+          --query "[0].version" \
+          -o tsv)
         
         echo "✅ Model registered successfully!"
         echo "   Name: diabetes-model"


### PR DESCRIPTION
- Changed the command to retrieve the model version from `az ml model show` to `az ml model list` for improved accuracy in fetching the latest version.
- Adjusted the query to ensure the correct version is extracted from the model list.