### PR TITLE
chore: update deployment configurations to use Standard_DS2_v2 and ad…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,3 @@
 {
-    "github-actions.workflows.pinned.workflows": [
-        ".github/workflows/07-deploy-model.yml",
-        ".github/workflows/06-train-and-deploy.yml",
-        ".github/workflows/05-pull-request-checks.yml"
-    ]
+    "github-actions.workflows.pinned.workflows": []
 }

--- a/src/deployment-green.yml
+++ b/src/deployment-green.yml
@@ -27,9 +27,9 @@ environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu@latest
 # Same compute settings as blue
 # IMPORTANT: Must match blue deployment for fair comparison!
 # Using same instance type ensures performance testing is accurate
-# Azure recommends DS3_v2 minimum for general purpose endpoints
-instance_type: Standard_DS3_v2
-instance_count: 1
+# Using DS2_v2 due to quota limits, matching blue deployment
+instance_type: Standard_DS2_v2
+instance_count: 2
 
 # Same request settings as blue
 request_settings:

--- a/src/deployment.yml
+++ b/src/deployment.yml
@@ -45,13 +45,14 @@ environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu@latest
 # Options: Standard_DS2_v2, Standard_DS3_v2, Standard_F4s_v2, etc.
 # DS3_v2 = 4 vCPUs, 14 GB RAM - good for moderate traffic (~$0.19/hour)
 # DS2_v2 = 2 vCPUs, 7 GB RAM - lower cost option (~$0.10/hour)
-# Azure recommends DS3_v2 minimum for general purpose endpoints
-instance_type: Standard_DS3_v2
+# Using DS2_v2 due to quota limits, but with multiple instances for reliability
+# DS2_v2 = 2 vCPUs, 7 GB RAM per instance
+instance_type: Standard_DS2_v2
 
 # Number of instances to run
-# Start with 1 for testing, increase based on load
-# Azure ML can auto-scale, but that requires additional configuration
-instance_count: 1
+# Using 2 instances to provide redundancy and better performance
+# This gives us 4 vCPUs total (2 instances × 2 vCPUs each)
+instance_count: 2
 
 # Resource requests and limits (optional but recommended for production)
 # This helps with cost management and prevents resource exhaustion


### PR DESCRIPTION
…just instance count

Modified the instance type in deployment-green.yml and deployment.yml to Standard_DS2_v2 due to quota limits, while increasing the instance count to 2 for improved reliability and performance.