### PR TITLE
chore: update deployment configurations to use Standard_F8s_v2

### DIFF
--- a/.github/workflows/06-train-and-deploy.yml
+++ b/.github/workflows/06-train-and-deploy.yml
@@ -83,9 +83,10 @@ jobs:
 
   production:
     name: Train Model - Production
+    if: ${{ false }}  # DISABLED FOR TESTING
     runs-on: ubuntu-latest
     environment: production
-    # needs: experiment
+    needs: experiment
     steps:
     - name: Check out repo
       uses: actions/checkout@v4

--- a/.github/workflows/07-deploy-model.yml
+++ b/.github/workflows/07-deploy-model.yml
@@ -205,8 +205,8 @@ jobs:
         echo "✅ Model deployed successfully!"
         
         # Wait for deployment to be ready and check status
-        echo "⏳ Waiting for deployment to be ready..."
-        sleep 60
+        echo "⏳ Waiting for deployment to be ready (some instances need more startup time)..."
+        sleep 90
         
         # Check deployment status and logs for debugging
         echo "🔍 Checking deployment status..."

--- a/src/deployment-green.yml
+++ b/src/deployment-green.yml
@@ -27,8 +27,8 @@ environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu@latest
 # Same compute settings as blue
 # IMPORTANT: Must match blue deployment for fair comparison!
 # Using same instance type ensures performance testing is accurate
-# Using D2s_v3 - different quota pool than DS series used by training cluster
-instance_type: Standard_D2s_v3
+# Using F8s_v2 - larger VM to avoid container crashes per Azure ML documentation
+instance_type: Standard_F8s_v2
 instance_count: 1
 
 # Same request settings as blue

--- a/src/deployment.yml
+++ b/src/deployment.yml
@@ -45,10 +45,10 @@ environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu@latest
 # Options: Standard_DS2_v2, Standard_DS3_v2, Standard_F4s_v2, etc.
 # DS3_v2 = 4 vCPUs, 14 GB RAM - good for moderate traffic (~$0.19/hour)
 # DS2_v2 = 2 vCPUs, 7 GB RAM - lower cost option (~$0.10/hour)
-# Using D2s_v3 - different quota pool than DS series used by training cluster
-# D2s_v3 = 2 vCPUs, 8 GB RAM (general purpose) - commonly supported for ML endpoints
-# This won't conflict with DS series quota used by training
-instance_type: Standard_D2s_v3
+# Using F8s_v2 - larger VM to avoid container crashes per Azure ML documentation
+# F8s_v2 = 8 vCPUs, 16 GB RAM (compute optimized) - recommended for larger models
+# Azure warns that F2s_v2 and F4s_v2 may be too small and cause container termination
+instance_type: Standard_F8s_v2
 
 # Number of instances to run
 # Start with 1 instance to minimize quota usage


### PR DESCRIPTION
Changed the instance type in deployment-green.yml and deployment.yml to Standard_F8s_v2 for improved performance and to prevent container crashes. Updated deployment workflow to increase wait time for deployment readiness and disabled the production training job for testing purposes.